### PR TITLE
Add broadcast CAN sensor type

### DIFF
--- a/backend/config/_readme.txt
+++ b/backend/config/_readme.txt
@@ -33,3 +33,13 @@
 //      max_value: 2,                       // Expected max. value for gauge setup
 //      limit_start: 1.5,                   // Start of redline for gauge setup
 //  },
+
+//  Broadcast example:
+//  "rpm_broadcast": {
+//      interface: "can1",
+//      type: "broadcast",                 // Read value from incoming frame
+//      rep_id: rep_id[0],                  // ID of the broadcast message
+//      data_bytes: [1, 6],                 // Byte indices containing the value
+//      is_16bit: true,
+//      scale: '(value * 1)'
+//  }

--- a/backend/config/profiles/2004_P1_T5/can.json
+++ b/backend/config/profiles/2004_P1_T5/can.json
@@ -172,6 +172,21 @@
             "max_value": 8000,
             "limit_start":7000
         },
+        "rpm_broadcast": {
+            "interface": "can2",
+            "enabled": false,
+            "type": "broadcast",
+            "rep_id": "0x02803008",
+            "data_bytes": [1, 6],
+            "app_id": "rpm",
+            "is_16bit": true,
+            "scale": "(value * 1)",
+            "label": "RPM",
+            "unit": "rpm",
+            "min_value": 0,
+            "max_value": 8000,
+            "limit_start": 7000
+        },
         "speed": {
             "interface": "can2",
             "enabled": false,

--- a/backend/config/profiles/2005_P2_D5/can.json
+++ b/backend/config/profiles/2005_P2_D5/can.json
@@ -172,6 +172,21 @@
             "max_value": 5000,
             "limit_start":4500
         },
+        "rpm_broadcast": {
+            "interface": "can1",
+            "enabled": false,
+            "type": "broadcast",
+            "rep_id": "0x02803008",
+            "data_bytes": [1, 6],
+            "app_id": "rpm",
+            "is_16bit": true,
+            "scale": "(value * 1)",
+            "label": "RPM",
+            "unit": "rpm",
+            "min_value": 0,
+            "max_value": 5000,
+            "limit_start": 4500
+        },
         "speed": {
             "interface": "can1",
             "enabled": false,


### PR DESCRIPTION
## Summary
- support a new `broadcast` CAN sensor type with configurable `data_bytes`
- document broadcast sensors in `_readme.txt`
- add optional RPM broadcast sensors in both default profiles
