### PR TITLE
Add live_sensors for CAN RPM broadcast

### DIFF
--- a/backend/config/_readme.txt
+++ b/backend/config/_readme.txt
@@ -34,16 +34,6 @@
 //      limit_start: 1.5,                   // Start of redline for gauge setup
 //  },
 
-//  Broadcast example:
-//  "rpm_broadcast": {
-//      interface: "can1",
-//      type: "broadcast",                 // Read value from incoming frame
-//      rep_id: rep_id[0],                  // ID of the broadcast message
-//      data_bytes: [1, 6],                 // Byte indices containing the value
-//      is_16bit: true,
-//      scale: '(value * 1)'
-//  }
-
 //  Live sensor example:
 //  "rpm": {
 //      interface: "can2",

--- a/backend/config/_readme.txt
+++ b/backend/config/_readme.txt
@@ -43,3 +43,12 @@
 //      is_16bit: true,
 //      scale: '(value * 1)'
 //  }
+
+//  Live sensor example:
+//  "rpm": {
+//      interface: "can2",
+//      rep_id: rep_id[0],                  // ID of the live message
+//      data_bytes: [6, 7],                 // Byte indices containing the value
+//      is_16bit: true,
+//      scale: '(value * 1)'
+//  }

--- a/backend/config/profiles/2004_P1_T5/can.json
+++ b/backend/config/profiles/2004_P1_T5/can.json
@@ -172,21 +172,6 @@
             "max_value": 8000,
             "limit_start":7000
         },
-        "rpm_broadcast": {
-            "interface": "can2",
-            "enabled": false,
-            "type": "broadcast",
-            "rep_id": "0x02803008",
-            "data_bytes": [1, 6],
-            "app_id": "rpm",
-            "is_16bit": true,
-            "scale": "(value * 1)",
-            "label": "RPM",
-            "unit": "rpm",
-            "min_value": 0,
-            "max_value": 8000,
-            "limit_start": 7000
-        },
         "speed": {
             "interface": "can2",
             "enabled": false,

--- a/backend/config/profiles/2004_P1_T5/can.json
+++ b/backend/config/profiles/2004_P1_T5/can.json
@@ -210,6 +210,22 @@
             "limit_start": 240
         }
     },
+    "live_sensors": {
+        "rpm": {
+            "interface": "can2",
+            "enabled": true,
+            "rep_id": "0x02803008",
+            "data_bytes": [6, 7],
+            "app_id": "rpm",
+            "is_16bit": true,
+            "scale": "(value * 1)",
+            "label": "RPM",
+            "unit": "rpm",
+            "min_value": 0,
+            "max_value": 8000,
+            "limit_start": 7000
+        }
+    },
     "controls": {
         "enabled": false,
         "interface": "",

--- a/backend/config/profiles/2005_P2_D5/can.json
+++ b/backend/config/profiles/2005_P2_D5/can.json
@@ -172,21 +172,6 @@
             "max_value": 5000,
             "limit_start":4500
         },
-        "rpm_broadcast": {
-            "interface": "can1",
-            "enabled": false,
-            "type": "broadcast",
-            "rep_id": "0x02803008",
-            "data_bytes": [1, 6],
-            "app_id": "rpm",
-            "is_16bit": true,
-            "scale": "(value * 1)",
-            "label": "RPM",
-            "unit": "rpm",
-            "min_value": 0,
-            "max_value": 5000,
-            "limit_start": 4500
-        },
         "speed": {
             "interface": "can1",
             "enabled": false,

--- a/backend/config/profiles/2005_P2_D5/can.json
+++ b/backend/config/profiles/2005_P2_D5/can.json
@@ -210,6 +210,22 @@
             "limit_start": 240
         }
     },
+    "live_sensors": {
+        "rpm": {
+            "interface": "can2",
+            "enabled": true,
+            "rep_id": "0x02803008",
+            "data_bytes": [6, 7],
+            "app_id": "rpm",
+            "is_16bit": true,
+            "scale": "(value * 1)",
+            "label": "RPM",
+            "unit": "rpm",
+            "min_value": 0,
+            "max_value": 5000,
+            "limit_start": 4500
+        }
+    },
     "controls": {
         "enabled": true,
         "interface": "can2",


### PR DESCRIPTION
## Summary
- extend CAN config handling with new `live_sensors` section
- support live sensors in `CANThread` and `CANListener`
- add RPM live sensor configuration for example profiles
- document live sensor example in `_readme.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cf365ce08832aac6163777ddc6b7c